### PR TITLE
write down error cases in `Job.run`

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -166,11 +166,10 @@ impl Job {
         } else if input.is_relative() {
             Ok(work_dir.join(input))
         } else {
-            bail!(
-                "couldn't isolate {} because it's outside the working directory ({})",
-                input.display(),
-                self.working_directory.display(),
-            );
+            bail!(Problem::InputWasOutsideWorkingDirectory(
+                input.to_path_buf(),
+                self.working_directory.to_path_buf(),
+            ))
         }
     }
 }
@@ -180,6 +179,7 @@ enum Problem {
     NoSymlinksForNow(PathBuf),
     UnhandledFileType(PathBuf),
     TargetHadNoParent(PathBuf),
+    InputWasOutsideWorkingDirectory(PathBuf, PathBuf),
 }
 
 impl fmt::Display for Problem {
@@ -204,6 +204,14 @@ impl fmt::Display for Problem {
                     f,
                     "couldn't create the directories leading to {}. That probably means it's at the filesystem root, but we should have excluded that possibility already. This is a bug and should be reported.",
                     path.display(),
+                ),
+
+            Problem::InputWasOutsideWorkingDirectory(path, working_directory) =>
+                write!(
+                    f,
+                    "couldn't isolate {} because it's outside the working directory ({})",
+                    path.display(),
+                    working_directory.display(),
                 ),
         }
     }

--- a/src/job.rs
+++ b/src/job.rs
@@ -107,7 +107,7 @@ impl Job {
                 bail!(Problem::NoSymlinksForNow(input.to_path_buf()));
             } else {
                 // could be a socket, block device, etc
-                bail!("I don't know how to thandle the filetype of {}. I know about directories, files, and symlinks.", input.display());
+                bail!(Problem::UnhandledFileType(input.to_path_buf()));
             }
         }
 
@@ -173,6 +173,7 @@ impl Job {
 #[derive(Debug)]
 enum Problem {
     NoSymlinksForNow(PathBuf),
+    UnhandledFileType(PathBuf),
 }
 
 impl fmt::Display for Problem {
@@ -183,6 +184,13 @@ impl fmt::Display for Problem {
                     f,
                     "{} was a symlink, but symlinks aren't allowed right. We can't make sure that they will be totally isolated on the filesystem. Sorry!",
                     path.display()
+                ),
+
+            Problem::UnhandledFileType(path) =>
+                write!(
+                    f,
+                    "I don't know how to handle the file type of {}. I know about directories, files, and symlinks.",
+                    path.display(),
                 ),
         }
     }


### PR DESCRIPTION
I'm not sure the best overall approach to error reporting for this code, but this moves some errors out of strings and into an enum. What else should we do here?